### PR TITLE
adding command-line option handling (compatible add-on to the previous approach for calling parcel from python!) (intentionally includes PR6)

### DIFF
--- a/parcel.py
+++ b/parcel.py
@@ -176,4 +176,6 @@ def parcel(dt=.1, z_max=200, w=1, T_0=300, p_0=101300, r_0=.022, outfile="test.n
     save_attrs(fout, info)
     save_attrs(fout, opts)
 
-parcel()
+# ensuring that pure "import parcel" does not trigger any simulation
+if __name__ == '__main__':
+  parcel()

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -9,7 +9,7 @@ def test_cmdline(tmpdir):
 
   # calling via subprocess
   file_sbproc = str(tmpdir.join("sbproc.nc"))
-  subprocess.check_call(["../parcel.py", "--outfile="+file_sbproc])
+  subprocess.check_call(["parcel.py", "--outfile="+file_sbproc])
 
   # comparing if the output is the same
   # TODO!

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -1,0 +1,15 @@
+import sys,subprocess,filecmp
+sys.path.insert(0, "../")
+import parcel
+
+def test_cmdline(tmpdir):
+  # calling from Python
+  file_python = str(tmpdir.join("python.nc"))
+  parcel.parcel(outfile=file_python)
+
+  # calling via subprocess
+  file_sbproc = str(tmpdir.join("sbproc.nc"))
+  subprocess.check_call(["../parcel.py", "--outfile="+file_sbproc])
+
+  # comparing if the output is the same
+  # TODO!


### PR DESCRIPTION
This enables one, in addition to using parcel from Python (via import parcel), to use it from command-line or Matlab/IDL/etc - not even knowing that parcel is written in Python

Example:
$ parcel.py --outfile=test.nc --T_0=300

Previous way of using it via import remains available and unchanged.
